### PR TITLE
Added tempLength while printing

### DIFF
--- a/data-structure-golang/linked-list/main.go
+++ b/data-structure-golang/linked-list/main.go
@@ -20,11 +20,12 @@ func (l *linkedList) prepend(n *node) {
 }
 
 func (l linkedList) printListData() {
+	tempLength := l.length
 	toPrint := l.head
-	for l.length != 0 {
+	for tempLength != 0 {
 		fmt.Printf("%d ", toPrint.data)
 		toPrint = toPrint.next
-		l.length--
+		tempLength--
 	}
 	fmt.Printf("\n")
 }


### PR DESCRIPTION
Added tempLength while printing to avoid making the length of the actual LinkedList to be 0 after printing the results.

### Behavior Before the Fix
State of LinkedList(myList) before printing:
```
{
    head: 0xblahblah
    length: 6
}
```
State of myList after printing:
```
{
    head: 0xblahblah
    length: 0 //while the length of the linkedList is still 6
}
```

### Behavior After the Fix
State of LinkedList(myList) before printing:
```
{
    head: 0xblahblah
    length: 6
}
```
State of myList after printing:
```
{
    head: 0xblahblah
    length: 6 //Added tempLength variable to maintain the original length to be 6 even after looping through it
}
```